### PR TITLE
Dagger bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 

--- a/neanderthal-no-op/build.gradle
+++ b/neanderthal-no-op/build.gradle
@@ -27,7 +27,7 @@ ext {
     siteUrl = 'https://github.com/outware/neanderthal/'
     gitUrl = 'https://github.com/outware/neanderthal.git'
 
-    libraryVersion = '1.0.0'
+    libraryVersion = '1.1.0'
 
     developerId = 'outware'
     developerName = 'Outware Mobile'
@@ -46,7 +46,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
         versionCode 1
-        versionName "1.0"
+        versionName "1.1.0"
     }
 
     buildTypes {
@@ -64,7 +64,7 @@ task sourcesJar(type: Jar) {
 }
 
 task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
+    source = android.sourceSets.main.java.sourceFiles
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
 }
 

--- a/neanderthal/build.gradle
+++ b/neanderthal/build.gradle
@@ -38,7 +38,7 @@ ext {
     siteUrl = 'https://github.com/outware/neanderthal/'
     gitUrl = 'https://github.com/outware/neanderthal.git'
 
-    libraryVersion = '1.0.0'
+    libraryVersion = '1.1.0'
 
     developerId = 'outware'
     developerName = 'Outware Mobile'
@@ -58,7 +58,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
         versionCode 1
-        versionName "1.0"
+        versionName "1.1.0"
     }
 
     buildTypes {
@@ -85,7 +85,8 @@ task sourcesJar(type: Jar) {
 }
 
 task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
+    failOnError false
+    source = android.sourceSets.main.java.sourceFiles
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
 }
 

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/application/NeanderthalApplication.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/application/NeanderthalApplication.kt
@@ -1,11 +1,9 @@
 package au.com.outware.neanderthal.application
 
 import android.app.Application
-import au.com.outware.neanderthal.dagger.component.ApplicationComponent
-import au.com.outware.neanderthal.dagger.component.DaggerApplicationComponent
-import au.com.outware.neanderthal.dagger.module.ApplicationModule
-import au.com.outware.neanderthal.domain.interactor.VariantInteractor
-import javax.inject.Inject
+import au.com.outware.neanderthal.dagger.component.DaggerNeanderthalApplicationComponent
+import au.com.outware.neanderthal.dagger.component.NeanderthalApplicationComponent
+import au.com.outware.neanderthal.dagger.module.NeanderthallApplicationModule
 
 /**
  * @author timmutton
@@ -13,21 +11,18 @@ import javax.inject.Inject
 open class NeanderthalApplication : Application() {
     companion object {
         @JvmStatic
-        lateinit var applicationComponent: ApplicationComponent
+        lateinit var neanderthalApplicationComponent: NeanderthalApplicationComponent
     }
 
-    @Inject
-    internal lateinit var variantInteractor: VariantInteractor
-
     fun initialise(klass: Class<out Any>, baseVariants: Map<String, Any>, defaultVariant: String) {
-        applicationComponent = DaggerApplicationComponent.builder()
-                .applicationModule(ApplicationModule(this, klass, baseVariants, defaultVariant))
+        neanderthalApplicationComponent = DaggerNeanderthalApplicationComponent.builder()
+                .neanderthallApplicationModule(NeanderthallApplicationModule(this, klass, baseVariants, defaultVariant))
                 .build()
-        applicationComponent.inject(this)
+        neanderthalApplicationComponent.inject(this)
     }
 
     @Suppress("UNCHECKED_CAST")
     fun <T> getConfiguration(): T {
-        return variantInteractor.getCurrentVariant()?.configuration as T
+        return neanderthalApplicationComponent.getVariantInteractor().getCurrentVariant()?.configuration as T
     }
 }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/dagger/component/EditVariantComponent.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/dagger/component/EditVariantComponent.kt
@@ -9,7 +9,7 @@ import dagger.Component
  * @author timmutton
  */
 @ActivityScope
-@Component(dependencies = arrayOf(ApplicationComponent::class), modules = arrayOf(EditVariantModule::class))
+@Component(dependencies = arrayOf(NeanderthalApplicationComponent::class), modules = arrayOf(EditVariantModule::class))
 interface EditVariantComponent {
     fun inject(activity: EditVariantActivity)
 }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/dagger/component/NeanderthalApplicationComponent.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/dagger/component/NeanderthalApplicationComponent.kt
@@ -2,7 +2,7 @@ package au.com.outware.neanderthal.dagger.component
 
 import android.content.Context
 import au.com.outware.neanderthal.application.NeanderthalApplication
-import au.com.outware.neanderthal.dagger.module.ApplicationModule
+import au.com.outware.neanderthal.dagger.module.NeanderthallApplicationModule
 import au.com.outware.neanderthal.data.repository.VariantRepository
 import au.com.outware.neanderthal.domain.factory.ConfigurationFactory
 import au.com.outware.neanderthal.domain.interactor.VariantInteractor
@@ -13,8 +13,8 @@ import javax.inject.Singleton
  * @author timmutton
  */
 @Singleton
-@Component(modules = arrayOf(ApplicationModule::class))
-interface ApplicationComponent {
+@Component(modules = arrayOf(NeanderthallApplicationModule::class))
+interface NeanderthalApplicationComponent {
     fun inject(application: NeanderthalApplication)
 
     fun getApplicationContext(): Context

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/dagger/component/VariantListComponent.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/dagger/component/VariantListComponent.kt
@@ -9,7 +9,7 @@ import dagger.Component
  * @author timmutton
  */
 @ActivityScope
-@Component(dependencies = arrayOf(ApplicationComponent::class), modules = arrayOf(VariantListModule::class))
+@Component(dependencies = arrayOf(NeanderthalApplicationComponent::class), modules = arrayOf(VariantListModule::class))
 interface VariantListComponent {
     fun inject(activity: VariantListActivity)
 }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/dagger/module/NeanderthallApplicationModule.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/dagger/module/NeanderthallApplicationModule.kt
@@ -16,10 +16,10 @@ import javax.inject.Singleton
  * @author timmutton
  */
 @Module
-class ApplicationModule(private val application: Application,
-                        private val klass: Class<out Any>,
-                        private val baseVariants: Map<String, Any>,
-                        private val defaultVariant: String) {
+class NeanderthallApplicationModule(private val application: Application,
+                                    private val klass: Class<out Any>,
+                                    private val baseVariants: Map<String, Any>,
+                                    private val defaultVariant: String) {
     @Provides
     @Singleton
     fun provideApplicationContext(): Context = application

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/EditVariantActivity.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/EditVariantActivity.kt
@@ -35,7 +35,7 @@ class EditVariantActivity : AppCompatActivity(), EditVariantPresenter.ViewSurfac
         val adapter = PropertyAdapter()
 
         DaggerEditVariantComponent.builder()
-            .applicationComponent(NeanderthalApplication.applicationComponent)
+            .neanderthalApplicationComponent(NeanderthalApplication.neanderthalApplicationComponent)
             .editVariantModule(EditVariantModule(this, adapter))
             .build()
             .inject(this)

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
@@ -39,7 +39,7 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
         adapter = VariantAdapter { name, position -> presenter.onItemSelected(name, position) }
 
         DaggerVariantListComponent.builder()
-                .applicationComponent(NeanderthalApplication.applicationComponent)
+                .neanderthalApplicationComponent(NeanderthalApplication.neanderthalApplicationComponent)
                 .variantListModule(VariantListModule(this, adapter))
                 .build()
                 .inject(this)


### PR DESCRIPTION
Using a generic name for the main component (application component) causes issues when applications also using dagger do the same thing, so to mitigate this ive renamed it NeanderthalApplicationComponent. Ive also removed the inject annotation in the NeanderthalApplication class and am instead retrieving the interactor manually as that also seems to cause conflict when the hosting app uses dagger. Also had to fix some javadoc issues to upload the fix
