### PR TITLE
Reset Variants to default values

### DIFF
--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/data/repository/VariantRepository.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/data/repository/VariantRepository.kt
@@ -10,8 +10,11 @@ interface VariantRepository {
     fun removeVariant(name: String)
 
     fun getVariants(): List<Variant>
+    fun getDefaultVariants(): List<Variant>
     fun getVariant(name: String): Variant?
 
     fun setCurrentVariant(name: String)
     fun getCurrentVariant(): Variant?
+
+    fun resetVariants()
 }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/data/repository/VariantRepository.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/data/repository/VariantRepository.kt
@@ -10,7 +10,6 @@ interface VariantRepository {
     fun removeVariant(name: String)
 
     fun getVariants(): List<Variant>
-    fun getDefaultVariants(): List<Variant>
     fun getVariant(name: String): Variant?
 
     fun setCurrentVariant(name: String)

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/data/repository/VariantSharedPreferencesRepository.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/data/repository/VariantSharedPreferencesRepository.kt
@@ -20,6 +20,7 @@ class VariantSharedPreferencesRepository(val klass: Class<out Any>,
         const val SHARED_PREFERENCES_FILE_NAME = "_neanderthal_preferences"
         const val VARIANT_LIST = "variant_list"
         const val CURRENT_VARIANT = "current_variant"
+        const val VARIANT_DEFAULT = "_default"
         const val VARIANT_STRUCTURE = "variant_structure"
     }
 
@@ -44,6 +45,7 @@ class VariantSharedPreferencesRepository(val klass: Class<out Any>,
             editor.putStringSet(VARIANT_LIST, baseVariants.keys)
             for (variant in baseVariants) {
                 editor.putString(variant.key, gson.toJson(variant.value))
+                editor.putString(variant.key + VARIANT_DEFAULT, gson.toJson(variant.value))
             }
             editor.putStringSet(VARIANT_STRUCTURE, structure)
             editor.putString(CURRENT_VARIANT, defaultVariant)

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/domain/interactor/VariantInteractor.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/domain/interactor/VariantInteractor.kt
@@ -12,4 +12,5 @@ interface VariantInteractor {
     fun getVariantNames(): List<String>
     fun removeVariant(name: String)
     fun setCurrentVariant(name: String)
+    fun resetVariants()
 }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/domain/interactor/VariantUseCases.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/domain/interactor/VariantUseCases.kt
@@ -47,4 +47,8 @@ class VariantUseCases(val variantRepository: VariantRepository, var configuratio
     override fun setCurrentVariant(name: String) {
         variantRepository.setCurrentVariant(name)
     }
+
+    override fun resetVariants() {
+        variantRepository.resetVariants()
+    }
 }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/adapter/VariantAdapter.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/adapter/VariantAdapter.kt
@@ -41,6 +41,7 @@ class VariantAdapter(var clickListener: (String, Int) -> Unit) :
     }
 
     override fun add(variants: List<String>) {
+        this.variants.removeAll(this.variants)
         this.variants.addAll(variants)
         notifyDataSetChanged()
     }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/presenter/VariantListPresenter.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/presenter/VariantListPresenter.kt
@@ -77,15 +77,11 @@ class VariantListPresenter @Inject constructor(): Presenter {
     }
 
     fun onEditClicked() {
-        if(variants.size > 0) {
-            view.goToEditVariant(currentVariantName)
-        }
+        view.goToEditVariant(currentVariantName)
     }
 
     fun onDeleteClicked() {
-        if(variants.size > 0) {
-            view.createDeleteConfirmation()
-        }
+        view.createDeleteConfirmation()
     }
 
     fun onAddVariant(name: String) {
@@ -93,6 +89,8 @@ class VariantListPresenter @Inject constructor(): Presenter {
         variants.add(name)
         variants.sort()
         adapter.add(variants)
+
+        view.updateOptionsMenu()
     }
 
     fun onResetToDefaultClicked(){
@@ -104,20 +102,18 @@ class VariantListPresenter @Inject constructor(): Presenter {
             variantInteractor.resetVariants()
             variants.clear()
 
-            val currentVariants : List<String> = variantInteractor.getVariantNames()
-            for(variant in currentVariants){
-                variants.add(variant)
-            }
+            variants.addAll(variantInteractor.getVariantNames())
 
             variants.sort()
             adapter.add(variants)
-            currentPosition = 0
-            currentVariantName = variants[0]
-            adapter.setCurrentPosition(0)
+            currentVariantName = variantInteractor.getCurrentVariant()?.name ?: variants.first()
+            currentPosition = variants.indexOf(currentVariantName)
+            adapter.setCurrentPosition(currentPosition)
             view.notifyReset()
         }
 
         view.dismissResetConfirmation()
+        view.updateOptionsMenu()
     }
 
     fun onDeleteConfirmation(confirmed: Boolean) {
@@ -142,6 +138,7 @@ class VariantListPresenter @Inject constructor(): Presenter {
         }
 
         view.dismissDeleteConfirmation()
+        view.updateOptionsMenu()
     }
 
     fun onUndoClicked() {
@@ -157,6 +154,10 @@ class VariantListPresenter @Inject constructor(): Presenter {
         view.goToMainApplication()
     }
 
+    fun getVariantListSize() : Int {
+        return variants.size
+    }
+
     interface ViewSurface {
         fun createDeleteConfirmation()
         fun dismissDeleteConfirmation()
@@ -167,6 +168,7 @@ class VariantListPresenter @Inject constructor(): Presenter {
         fun goToAddVariant()
         fun goToEditVariant(name: String)
         fun goToMainApplication()
+        fun updateOptionsMenu()
     }
 
     interface AdapterSurface {

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/presenter/VariantListPresenter.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/presenter/VariantListPresenter.kt
@@ -2,6 +2,7 @@ package au.com.outware.neanderthal.presentation.presenter
 
 import android.os.Bundle
 import au.com.outware.neanderthal.data.model.Variant
+import au.com.outware.neanderthal.data.repository.VariantSharedPreferencesRepository
 import au.com.outware.neanderthal.domain.interactor.VariantInteractor
 import java.util.*
 import javax.inject.Inject
@@ -81,6 +82,26 @@ class VariantListPresenter @Inject constructor(): Presenter {
         adapter.add(name)
     }
 
+    fun onResetToDefaultClicked(){
+        view.createResetConfirmation()
+    }
+
+    fun onResetConfirmation(confirmed: Boolean){
+        if(confirmed) {
+            val variants : List<String> = variantInteractor.getVariantNames()
+            for(variant : String in variants){
+                var currentVariant = variantInteractor.getVariant(variant)
+                var defaultVariant = variantInteractor.getVariant(variant + VariantSharedPreferencesRepository.VARIANT_DEFAULT)
+                currentVariant.configuration = defaultVariant.configuration
+                variantInteractor.createOrUpdateVariant(currentVariant)
+            }
+
+            view.notifyReset()
+        }
+
+        view.dismissResetConfirmation()
+    }
+
     fun onDeleteConfirmation(confirmed: Boolean) {
         if (confirmed) {
             deletedVariant = variantInteractor.getCurrentVariant()
@@ -120,6 +141,9 @@ class VariantListPresenter @Inject constructor(): Presenter {
         fun createDeleteConfirmation()
         fun dismissDeleteConfirmation()
         fun notifyDeleted()
+        fun createResetConfirmation()
+        fun dismissResetConfirmation()
+        fun notifyReset()
         fun goToAddVariant()
         fun goToEditVariant(name: String)
         fun goToMainApplication()

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/presenter/VariantListPresenter.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/presenter/VariantListPresenter.kt
@@ -90,7 +90,7 @@ class VariantListPresenter @Inject constructor(): Presenter {
         variants.sort()
         adapter.add(variants)
 
-        view.updateOptionsMenu()
+        updateEditingEnabled()
     }
 
     fun onResetToDefaultClicked(){
@@ -113,7 +113,7 @@ class VariantListPresenter @Inject constructor(): Presenter {
         }
 
         view.dismissResetConfirmation()
-        view.updateOptionsMenu()
+        updateEditingEnabled()
     }
 
     fun onDeleteConfirmation(confirmed: Boolean) {
@@ -130,6 +130,9 @@ class VariantListPresenter @Inject constructor(): Presenter {
                 currentVariantName = variants[currentPosition]
                 variantInteractor.setCurrentVariant(currentVariantName)
                 adapter.setCurrentPosition(currentPosition)
+            }else{
+                currentPosition = 0
+                currentVariantName = ""
             }
 
             // Notify the views
@@ -138,7 +141,7 @@ class VariantListPresenter @Inject constructor(): Presenter {
         }
 
         view.dismissDeleteConfirmation()
-        view.updateOptionsMenu()
+        updateEditingEnabled()
     }
 
     fun onUndoClicked() {
@@ -154,8 +157,8 @@ class VariantListPresenter @Inject constructor(): Presenter {
         view.goToMainApplication()
     }
 
-    fun getVariantListSize() : Int {
-        return variants.size
+    fun updateEditingEnabled() {
+        view.setEditingEnabled(variants.size != 0)
     }
 
     interface ViewSurface {
@@ -168,7 +171,7 @@ class VariantListPresenter @Inject constructor(): Presenter {
         fun goToAddVariant()
         fun goToEditVariant(name: String)
         fun goToMainApplication()
-        fun updateOptionsMenu()
+        fun setEditingEnabled(enabled : Boolean)
     }
 
     interface AdapterSurface {

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
@@ -48,6 +48,8 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
         variantList.adapter = adapter
 
         buttonAdd.setOnClickListener { view -> presenter.onAddClicked() }
+
+        reset_to_default_button.setOnClickListener{ presenter.onResetToDefaultClicked() }
     }
 
     override fun onCreateOptionsMenu(menu: Menu?) = inflateMenu(R.menu.neanderthal_menu_variant_list, menu)
@@ -127,11 +129,29 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
         this.dialog = null
     }
 
+    override fun createResetConfirmation() {
+        dialog = AlertDialog.Builder(this)
+                .setTitle(R.string.neanderthal_reset_title)
+                .setMessage(R.string.neanderthal_reset_message)
+                .setPositiveButton(R.string.neanderthal_reset_positive) { dialog, which -> presenter.onResetConfirmation(true) }
+                .setNegativeButton(R.string.neanderthal_cancel) { dialog, which -> presenter.onResetConfirmation(false) }
+                .show()
+    }
+
+    override fun dismissResetConfirmation() {
+        dialog?.dismiss()
+        this.dialog = null
+    }
+
     override fun notifyDeleted() {
         layoutRoot.snackbar(R.string.neanderthal_delete_notice_message) {
             action(R.string.neanderthal_delete_notice_action) {
                 presenter.onUndoClicked()
             }
         }
+    }
+
+    override fun notifyReset() {
+        layoutRoot.snackbar(R.string.neanderthal_reset_notice_message)
     }
 }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
@@ -48,8 +48,6 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
         variantList.adapter = adapter
 
         buttonAdd.setOnClickListener { view -> presenter.onAddClicked() }
-
-        reset_to_default_button.setOnClickListener{ presenter.onResetToDefaultClicked() }
     }
 
     override fun onCreateOptionsMenu(menu: Menu?) = inflateMenu(R.menu.neanderthal_menu_variant_list, menu)
@@ -59,6 +57,7 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
             R.id.neanderthal_menu_item_edit -> presenter.onEditClicked()
             R.id.neanderthal_menu_item_delete -> presenter.onDeleteClicked()
             R.id.neanderthal_menu_item_launch_application -> presenter.onLaunchClicked()
+            R.id.neanderthal_menu_item_reset -> presenter.onResetToDefaultClicked()
         }
 
         return super.onOptionsItemSelected(item)

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
@@ -63,6 +63,13 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
         return super.onOptionsItemSelected(item)
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
+        menu!!.findItem(R.id.neanderthal_menu_item_delete).setVisible(presenter.getVariantListSize() != 0)
+        menu!!.findItem(R.id.neanderthal_menu_item_edit).setVisible(presenter.getVariantListSize() != 0)
+
+        return super.onPrepareOptionsMenu(menu)
+    }
+
     override fun onPause() {
         super.onPause()
         presenter.onPause()
@@ -152,5 +159,9 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
 
     override fun notifyReset() {
         layoutRoot.snackbar(R.string.neanderthal_reset_notice_message)
+    }
+
+    override fun updateOptionsMenu(){
+        invalidateOptionsMenu()
     }
 }

--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/presentation/view/activity/VariantListActivity.kt
@@ -28,6 +28,7 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
 
     private lateinit var adapter: VariantAdapter
     private var dialog: AlertDialog? = null
+    private var allowEditing: Boolean = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -64,8 +65,10 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
     }
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
-        menu!!.findItem(R.id.neanderthal_menu_item_delete).setVisible(presenter.getVariantListSize() != 0)
-        menu!!.findItem(R.id.neanderthal_menu_item_edit).setVisible(presenter.getVariantListSize() != 0)
+        menu?.let {
+            menu.findItem(R.id.neanderthal_menu_item_delete).setVisible(allowEditing)
+            menu.findItem(R.id.neanderthal_menu_item_edit).setVisible(allowEditing)
+        }
 
         return super.onPrepareOptionsMenu(menu)
     }
@@ -161,7 +164,8 @@ class VariantListActivity : AppCompatActivity(), VariantListPresenter.ViewSurfac
         layoutRoot.snackbar(R.string.neanderthal_reset_notice_message)
     }
 
-    override fun updateOptionsMenu(){
+    override fun setEditingEnabled(enabled : Boolean){
+        allowEditing = enabled
         invalidateOptionsMenu()
     }
 }

--- a/neanderthal/src/main/res/layout/neanderthal_activity_variant_list.xml
+++ b/neanderthal/src/main/res/layout/neanderthal_activity_variant_list.xml
@@ -18,12 +18,4 @@
         android:layout_margin="@dimen/neanderthal_activity_margin"
         android:src="@drawable/neanderthal_ic_add_white_24dp"
         app:elevation="4dp"/>
-
-    <Button
-        android:id="@+id/reset_to_default_button"
-        android:layout_gravity="center"
-        android:layout_marginBottom="5dp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/neanderthal_reset_default_values"/>
 </android.support.design.widget.CoordinatorLayout>

--- a/neanderthal/src/main/res/layout/neanderthal_activity_variant_list.xml
+++ b/neanderthal/src/main/res/layout/neanderthal_activity_variant_list.xml
@@ -18,4 +18,12 @@
         android:layout_margin="@dimen/neanderthal_activity_margin"
         android:src="@drawable/neanderthal_ic_add_white_24dp"
         app:elevation="4dp"/>
+
+    <Button
+        android:id="@+id/reset_to_default_button"
+        android:layout_gravity="center"
+        android:layout_marginBottom="5dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/neanderthal_reset_default_values"/>
 </android.support.design.widget.CoordinatorLayout>

--- a/neanderthal/src/main/res/menu/neanderthal_menu_variant_list.xml
+++ b/neanderthal/src/main/res/menu/neanderthal_menu_variant_list.xml
@@ -19,4 +19,9 @@
         app:showAsAction="never"
         android:showAsAction="never"
         tools:ignore="AlwaysShowAction,AppCompatResource" />
+    <item android:id="@+id/neanderthal_menu_item_reset"
+        android:title="@string/neanderthal_reset_default_values"
+        app:showAsAction="never"
+        android:showAsAction="never"
+        tools:ignore="AlwaysShowAction,AppCompatResource" />
 </menu>

--- a/neanderthal/src/main/res/values/strings.xml
+++ b/neanderthal/src/main/res/values/strings.xml
@@ -12,6 +12,10 @@
     <string name="neanderthal_delete_message">Delete selected variant?</string>
     <string name="neanderthal_delete_positive">Delete</string>
     <string name="neanderthal_delete_notice_message">Variant deleted</string>
+    <string name="neanderthal_reset_title">Reset Variants</string>
+    <string name="neanderthal_reset_message">Reset all variants to default values?</string>
+    <string name="neanderthal_reset_positive">Reset</string>
+    <string name="neanderthal_reset_notice_message">Variants reset</string>
     <string name="neanderthal_delete_notice_action">Undo</string>
     <string name="neanderthal_cancel_title">Cancel Changes</string>
     <string name="neanderthal_cancel_message">Are you sure you want to go back? Any changes will be lost</string>
@@ -23,4 +27,5 @@
     <string name="neanderthal_title_add_variant">Add Variant</string>
     <string name="neanderthal_name_required">Required</string>
     <string name="neanderthal_done">Done</string>
+    <string name="neanderthal_reset_default_values">Reset to default</string>
 </resources>


### PR DESCRIPTION
- Added a constant for the default variants shared preference entry "_default" to be appended to each variant as it gets initialised and store a copy of each value from the variant into the default alias
- Added a button to the variant list layout
- Added onClick listener to button to loop through the variants and set each configuration to the default values then commit back to the repository
- Display confirmation dialog and snackbar in-line with delete variant functionality
