### PR TITLE
[hotfix] Updated the cast to allow for null.

### DIFF
--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/Neanderthal.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/Neanderthal.kt
@@ -24,8 +24,8 @@ class Neanderthal {
 
         @Suppress("UNCHECKED_CAST")
         @JvmStatic
-        fun <T> getConfiguration(): T {
-            return variantRepository?.getCurrentVariant()?.configuration as T
+        fun <T> getConfiguration(): T? {
+            return variantRepository?.getCurrentVariant()?.configuration as T?
         }
     }
 }


### PR DESCRIPTION
Because it's unchecked the nullability of the value gets lost when integrating into the app.
This way we can handle it properly.