### PR TITLE
Prevent wrong or null endpoints returned if updating apps with variant changed.

### DIFF
--- a/neanderthal/src/main/kotlin/au/com/outware/neanderthal/data/repository/VariantSharedPreferencesRepository.kt
+++ b/neanderthal/src/main/kotlin/au/com/outware/neanderthal/data/repository/VariantSharedPreferencesRepository.kt
@@ -74,6 +74,7 @@ class VariantSharedPreferencesRepository(val klass: Class<out Any>,
         baseVariants.forEach { variant ->
             editor.putString(variant.key + VARIANT_DEFAULT, gson.toJson(variant.value))
         }
+        editor.apply()
     }
 
     override fun addVariant(variant: Variant) {


### PR DESCRIPTION
When endpoint configuration was changed, the shared preference should clear all old data and store the modified data immediately. If the Editor isn't applied, it will return wrong or null endpoint.